### PR TITLE
update: adjusted import naming

### DIFF
--- a/src/Netshell/Paypal/Paypal.php
+++ b/src/Netshell/Paypal/Paypal.php
@@ -25,7 +25,7 @@ use PayPal\Api\Sale;
 use PayPal\Api\ShippingAddress;
 use PayPal\Api\Transaction;
 use PayPal\Api\Transactions;
-use PayPal\Core\PPConfigManager;
+use PayPal\Core\PayPalConfigManager as PPConfigManager;
 use PayPal\Rest\ApiContext;
 use PayPal\Auth\OAuthTokenCredential;
 


### PR DESCRIPTION
PayPal SDK renamed the PPConfigManager class to PayPalConfigManager.
