### PR TITLE
Fix ssl error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "illuminate/support": "~5.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "paypal/rest-api-sdk-php": "1.3.2"
+        "paypal/rest-api-sdk-php": "1.6.4"
     },
     "require-dev":{
         "phpspec/phpspec": "~2.0"


### PR DESCRIPTION
Update paypal sdk to 1.6.4 
- CURLOPT_SSLVERSION fix 
