### PR TITLE
Replacing deprecated share method to singleton

### DIFF
--- a/src/Netshell/Paypal/PaypalServiceProvider.php
+++ b/src/Netshell/Paypal/PaypalServiceProvider.php
@@ -43,8 +43,7 @@ class PaypalServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app['Paypal'] = $this->app->share(function($app)
-        {
+        $this->app->singleton('Paypal',function($app){
             return new Paypal();
         });
     }


### PR DESCRIPTION
app->share method is deprecated on Laravel 5 and removed on 5.4 making the plugin non-usable for this version and beyond.