### PR TITLE
Please update paypal SDK to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=7.0.0",
         "illuminate/support": "~5.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "paypal/rest-api-sdk-php": "1.6.4"
+        "paypal/rest-api-sdk-php": "1.13.0"
     },
     "require-dev":{
         "phpspec/phpspec": "~2.0"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "netshell/paypal",
+    "name": "bogdangoia/paypal",
     "description": "Laravel-Paypal is simple package help you process direct credit card payments, stored credit card payments and PayPal account payments with your Laravel 5 projects using paypal REST API SDK.",
     "license": "BSD-2-Clause",
     "authors": [


### PR DESCRIPTION
I get this error: geting error sizeof(): Parameter must be an array or an object that implements Countable

The error is in the paypal\rest-api-sdk-php package you are using. The version of the package you are using is, apparently, not exactly compatible with PHP 7.2.

The specific error you are getting has been fixed in the latest version of the package (1.13.0). Update the package to the latest version, and this issue will be fixed. I cannot say what other issues may pop up, though.

In the 1.12.0 version, the specific line that is failing is:

} elseif (sizeof($v) <= 0 && is_array($v)) {

In PHP 7.2, if $v is not Countable, the sizeof() call will emit a warning, and Laravel will turn that warning into an exception.

In the 1.13.0 version, they updated the condition to be

} elseif (is_array($v) && sizeof($v) <= 0) {

Now, sizeof() will only be called when $v is an array, and therefore is guaranteed to be Countable, thus eliminating the warning.

https://stackoverflow.com/a/49506993