### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "illuminate/support": "~5.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "paypal/rest-api-sdk-php": "1.6.4"
+        "paypal/rest-api-sdk-php": "1.13.0"
     },
     "require-dev":{
         "phpspec/phpspec": "~2.0"


### PR DESCRIPTION
Update the paypal/rest-api-sdk-php dependency in order to remove the warning (error for Laravel) (see PayPal-PHP-SDK/lib/PayPal/Common/PayPalModel.php: 178)